### PR TITLE
raise ValueError if not a np ndarray (or pandas DataFrame)

### DIFF
--- a/inmoose/pycombat/pycombat_seq.py
+++ b/inmoose/pycombat/pycombat_seq.py
@@ -62,8 +62,10 @@ def pycombat_seq(data, batch, group=None, covar_mod=None, full_mod=True, shrink=
         list_samples = data.columns
         list_genes = data.index
         counts = data.values
-    else:
+    elif isinstance(data, np.ndarray):
         counts = data
+    else:
+        raise ValueError("data must be a pandas dataframe or a numpy nd array")
 
     ####### Preparation #######
     # make sure batch is a factor


### PR DESCRIPTION
A small change which addresses  #10. Can help to avoid "non-broadcastable output operand" error for input matrices when they are either dense matrices that are not np ndarray, or sparse matrices (both of which I found to trigger this error).