### PR TITLE
Improve covariates use

### DIFF
--- a/inmoose/pycombat/pycombat_norm.py
+++ b/inmoose/pycombat/pycombat_norm.py
@@ -625,6 +625,10 @@ def pycombat_norm(
 
     design = np.transpose(design)
 
+    # Raise error if single-sample batch, code does not support 1 sample per batch
+    if 1 in n_batches:
+        raise ValueError(f"pycombat_norm doesn't support 1 sample per batch")
+
     # Check for missing values in count matrix
     NAs = np.isnan(dat).any()
     if NAs:

--- a/inmoose/pycombat/pycombat_norm.py
+++ b/inmoose/pycombat/pycombat_norm.py
@@ -559,6 +559,7 @@ def pycombat_norm(
     mean_only=False,
     ref_batch=None,
     precision=None,
+    cov_missing_value=None,
     **kwargs,
 ):
     """Corrects batch effect in microarray expression data. Takes an gene expression file and a list of known batches corresponding to each sample.
@@ -583,6 +584,12 @@ def pycombat_norm(
         batch id of the batch to use as reference (default: `None`)
     precision : float, optional
         level of precision for precision computing (default: `None`).
+    cov_missing_value : str
+        Option to choose the way to handle missing covariates
+        `None` raise an error if missing covariates and stop the code
+        `remove` remove samples with missing covariates and raise a warning
+        `fill` handle missing covariates, by creating a distinct covariate per batch
+        (default: `None`)
 
     Returns
     -------
@@ -600,6 +607,7 @@ def pycombat_norm(
 
     check_mean_only(mean_only)
 
+    # Handle batches, covariates and prepare design matrix
     (
         design,
         batchmod,
@@ -609,7 +617,12 @@ def pycombat_norm(
         n_batch,
         n_array,
         ref,
-    ) = make_design_matrix(dat, batch, covar_mod, ref_batch)
+        batch,
+        remove_sample,
+    ) = make_design_matrix(dat, batch, covar_mod, ref_batch, cov_missing_value)
+    # Remove samples with NaN in covariates
+    dat = [dat[n_col] for n_col in range(0, len(dat)) if n_col not in remove_sample]
+
     design = np.transpose(design)
 
     # Check for missing values in count matrix

--- a/inmoose/pycombat/pycombat_norm.py
+++ b/inmoose/pycombat/pycombat_norm.py
@@ -553,7 +553,7 @@ def adjust_data(
 def pycombat_norm(
     data,
     batch,
-    mod=None,
+    covar_mod=None,
     par_prior=True,
     prior_plots=False,
     mean_only=False,
@@ -569,8 +569,10 @@ def pycombat_norm(
         expression matrix (dataframe or numpy array). It contains the information about the gene expression (rows) for each sample (columns).
     batch : list
         batch indices. Must have as many elements as the number of columns in the expression matrix.
-    mod : matrix, optional
-        matrix model for multiple covariates to include in linear model (signal from these variables are kept in data after adjustment)
+    covar_mod : list or matrix, optional
+        model matrix (dataframe, list or numpy array) for one or multiple covariates to include in linear model (signal
+        from these variables are kept in data after adjustment). Covariates have to be categorial,
+        they can not be continious values (default: `None`).
     par_prior : bool, optional
         False for non-parametric estimation of batch effects (default: `True`).
     prior_plots : bool, optional
@@ -607,7 +609,7 @@ def pycombat_norm(
         n_batch,
         n_array,
         ref,
-    ) = make_design_matrix(dat, batch, None, mod, True, ref_batch)
+    ) = make_design_matrix(dat, batch, covar_mod, ref_batch)
     design = np.transpose(design)
 
     # Check for missing values in count matrix

--- a/inmoose/pycombat/pycombat_seq.py
+++ b/inmoose/pycombat/pycombat_seq.py
@@ -31,9 +31,7 @@ from .helper_seq import vec2mat, match_quantiles
 def pycombat_seq(
     data,
     batch,
-    group=None,
     covar_mod=None,
-    full_mod=True,
     shrink=False,
     shrink_disp=False,
     gene_subset_n=None,
@@ -47,12 +45,10 @@ def pycombat_seq(
         raw count matrix (dataframe or numpy array) from genomic studies (dimensions gene x sample)
     batch : array or list or :obj:`inmoose.utils.factor.Factor`
         Batch indices. Must have as many elements as the number of columns in the expression matrix.
-    group : array or list or :obj:`inmoose.utils.factor.Factor`, optional
-        vector/factor for biological condition of interest (default: `None`)
-    covar_mod : matrix, optional
-        model matrix for multiple covariates to include in linear model (signal from these variables are kept in data after adjustment)
-    full_mod : bool, optional
-        if True, include condition of interest in model
+    covar_mod : list or matrix, optional
+        model matrix (dataframe, list or numpy array) for one or multiple covariates to include in linear model (signal
+        from these variables are kept in data after adjustment). Covariates have to be categorial,
+        they can not be continious values (default: `None`).
     shrink : bool, optional
         whether to apply shrinkage on parameter estimation
     shrink_disp : bool, optional
@@ -101,7 +97,7 @@ def pycombat_seq(
         n_batch,
         n_sample,
         ref_batch_index,
-    ) = make_design_matrix(counts, batch, group, covar_mod, full_mod, ref_batch)
+    ) = make_design_matrix(counts, batch, covar_mod, ref_batch)
 
     # Check for missing values in count matrix
     if np.isnan(counts).any():

--- a/inmoose/pycombat/pycombat_seq.py
+++ b/inmoose/pycombat/pycombat_seq.py
@@ -99,6 +99,10 @@ def pycombat_seq(
     # Remove samples
     counts = np.delete(counts, (remove_sample), axis=1)
 
+    # Raise error if single-sample batch, code does not support 1 sample per batch
+    if 1 in n_batches:
+        raise ValueError("pycombat_seq doesn't support 1 sample per batch")
+
     # Remove genes with only 0 counts in any batch
     keep = np.full((counts.shape[0],), True)
     for b in batch.categories:

--- a/tests/pycombat/test_covariates.py
+++ b/tests/pycombat/test_covariates.py
@@ -9,7 +9,7 @@ class Test(unittest.TestCase):
         batch = np.asarray([1, 1, 1, 2, 2, 3, 3, 3, 3])
 
         counts = np.ones((100, 5))
-        _, _, mod, _, _, _, _, _ = make_design_matrix(
+        _, _, mod, _, _, _, _, _, _, _ = make_design_matrix(
             counts, [0, 0, 0, 0, 0], [1, 1, 0, 1, 0], None
         )
         self.assertEqual(mod.shape, (5, 2))
@@ -26,6 +26,8 @@ class Test(unittest.TestCase):
             n_batches,
             n_batch,
             n_sample,
+            _,
+            _,
             _,
         ) = make_design_matrix(counts, batch, None, None)
         self.assertEqual(batchmod.shape, (9, 3))

--- a/tests/pycombat/test_covariates.py
+++ b/tests/pycombat/test_covariates.py
@@ -10,7 +10,7 @@ class Test(unittest.TestCase):
 
         counts = np.ones((100, 5))
         _, _, mod, _, _, _, _, _ = make_design_matrix(
-            counts, [0, 0, 0, 0, 0], [1, 1, 0, 1, 0], None, True, None
+            counts, [0, 0, 0, 0, 0], [1, 1, 0, 1, 0], None
         )
         self.assertEqual(mod.shape, (5, 2))
         self.assertTrue(
@@ -27,7 +27,7 @@ class Test(unittest.TestCase):
             n_batch,
             n_sample,
             _,
-        ) = make_design_matrix(counts, batch, None, None, True, None)
+        ) = make_design_matrix(counts, batch, None, None)
         self.assertEqual(batchmod.shape, (9, 3))
 
         # test batches
@@ -42,8 +42,6 @@ class Test(unittest.TestCase):
         self.assertEqual(np.sum(design - batchmod), 0)
 
         # test reference batch
-        self.assertEqual(0, make_design_matrix(counts, batch, None, None, True, 1)[7])
-        self.assertEqual(1, make_design_matrix(counts, batch, None, None, True, 2)[7])
-        self.assertEqual(
-            None, make_design_matrix(counts, batch, None, None, True, None)[7]
-        )
+        self.assertEqual(0, make_design_matrix(counts, batch, None, 1)[7])
+        self.assertEqual(1, make_design_matrix(counts, batch, None, 2)[7])
+        self.assertEqual(None, make_design_matrix(counts, batch, None, None)[7])

--- a/tests/pycombat/test_pycombat.py
+++ b/tests/pycombat/test_pycombat.py
@@ -57,7 +57,16 @@ class test_pycombat(unittest.TestCase):
             self.n_batch,
             self.n_array,
             ref,
+            batch,
+            remove_sample,
         ) = make_design_matrix(self.dat, self.batch, mod, ref_batch)
+        # Remove samples with NaN in covariates
+        self.dat = [
+            self.dat[n_col]
+            for n_col in range(0, len(self.dat))
+            if n_col not in remove_sample
+        ]
+
         self.design = np.transpose(design)
 
         NAs = check_NAs(self.dat)

--- a/tests/pycombat/test_pycombat.py
+++ b/tests/pycombat/test_pycombat.py
@@ -57,7 +57,7 @@ class test_pycombat(unittest.TestCase):
             self.n_batch,
             self.n_array,
             ref,
-        ) = make_design_matrix(self.dat, self.batch, None, mod, True, ref_batch)
+        ) = make_design_matrix(self.dat, self.batch, mod, ref_batch)
         self.design = np.transpose(design)
 
         NAs = check_NAs(self.dat)

--- a/tests/pycombat/test_pycombat.py
+++ b/tests/pycombat/test_pycombat.py
@@ -177,7 +177,6 @@ class test_pycombat(unittest.TestCase):
         )
         # test raise error for single sample batch
         with self.assertRaisesRegex(
-            ValueError,
-            r"pycombat_norm doesn't support 1 sample per batch"
+            ValueError, r"pycombat_norm doesn't support 1 sample per batch"
         ):
             pycombat_norm(self.matrix, np.asarray([1, 1, 1, 2, 2, 3, 3, 3, 4]))

--- a/tests/pycombat/test_pycombat.py
+++ b/tests/pycombat/test_pycombat.py
@@ -19,7 +19,6 @@ from inmoose.pycombat import pycombat_norm
 class test_pycombat(unittest.TestCase):
     @classmethod
     def setUpClass(self):
-        self.batch = np.asarray([1, 1, 1, 2, 2, 3, 3, 3, 3])
         matrix = np.transpose(
             [
                 np.random.normal(size=1000, loc=3, scale=1),
@@ -39,6 +38,9 @@ class test_pycombat(unittest.TestCase):
             columns=["sample_" + str(i + 1) for i in range(9)],
             index=["gene_" + str(i + 1) for i in range(1000)],
         )
+
+        # test normal execution
+        self.batch = np.asarray([1, 1, 1, 2, 2, 3, 3, 3, 3])
         self.matrix_adjusted = pycombat_norm(self.matrix, self.batch)
 
         # useful constants for unit testing
@@ -173,3 +175,9 @@ class test_pycombat(unittest.TestCase):
         self.assertTrue(
             np.var(self.matrix_adjusted.values) <= np.var(self.matrix.values)
         )
+        # test raise error for single sample batch
+        with self.assertRaisesRegex(
+            ValueError,
+            r"pycombat_norm doesn't support 1 sample per batch"
+        ):
+            pycombat_norm(self.matrix, np.asarray([1, 1, 1, 2, 2, 3, 3, 3, 4]))

--- a/tests/pycombat/test_pycombatseq.py
+++ b/tests/pycombat/test_pycombatseq.py
@@ -87,16 +87,16 @@ class test_pycombatseq(unittest.TestCase):
         with self.assertRaisesRegex(
             ValueError, expected_regex="pycombat_seq doesn't support 1 sample per batch"
         ):
-            pycombat_seq(self.y, [1, 2, 2, 2, 2])
+            pycombat_seq(self.y, ["a", "b", "b", "b", "b"])
 
         # test with incomplete group
         with self.assertRaisesRegex(
             ValueError,
             expected_regex="2 values are missing in covariates col_0. Correct your covariates or use the cov_missing_value parameters",
         ):
-            pycombat_seq(self.y, self.batch, covar_mod=[1, np.nan, 1, np.nan, 1])
+            pycombat_seq(self.y, self.batch, covar_mod=["a", np.nan, "a", np.nan, "a"])
 
-        ref = pycombat_seq(self.y, self.batch, covar_mod=[1, 2, 1, 3, 1])
+        ref = pycombat_seq(self.y, self.batch, covar_mod=["a", "b", "a", "c", "a"])
         with self.assertWarnsRegex(
             UserWarning,
             r"1 missing covariates in covar_mod. Creating a distinct covariate per batch for the missing values. You may want to double check your covariates.",
@@ -123,3 +123,24 @@ class test_pycombatseq(unittest.TestCase):
         ref_batch = np.array([1, 1, 2, 2])
         ref = pycombat_seq(ref_y, ref_batch, covar_mod=[1, 2, 1, 1])
         self.assertTrue(np.array_equal(res, ref))
+
+        # test error/warning message for data type of covariates
+        with self.assertRaisesRegex(
+            ValueError,
+            expected_regex=r"Found numerical covariates with decimal col_0 in covar_mod parameters. Numerical covariates are not accepted. Please remove them before proceeding with pycombat.",
+        ):
+            pycombat_seq(
+                self.y,
+                self.batch,
+                covar_mod=[1, 2.9, 1, 1, 1],
+            )
+
+        with self.assertWarnsRegex(
+            UserWarning,
+            expected_regex=r"Found intereger covariates col_0 in covar_mod parameters. Numerical covariates are not accepted, these covariates will be process as categorial. You may want to double check your covariates.",
+        ):
+            pycombat_seq(
+                self.y,
+                self.batch,
+                covar_mod=[1, 2, 1, 2, 1],
+            )

--- a/tests/pycombat/test_pycombatseq.py
+++ b/tests/pycombat/test_pycombatseq.py
@@ -67,7 +67,7 @@ class test_pycombatseq(unittest.TestCase):
                 [19, 21, 22, 17],
             ]
         )
-        res = pycombat_seq(self.y, self.batch, group=[1, 1, 1, 2])
+        res = pycombat_seq(self.y, self.batch, covar_mod=[1, 1, 1, 2])
         self.assertTrue(np.array_equal(res, ref))
 
         # test with reference batch
@@ -84,10 +84,10 @@ class test_pycombatseq(unittest.TestCase):
         self.assertTrue(np.array_equal(res, res2))
 
         # test with incomplete group
-        ref = pycombat_seq(self.y, self.batch, group=[1, 2, 1, 3])
+        ref = pycombat_seq(self.y, self.batch, covar_mod=[1, 2, 1, 3])
         with self.assertWarnsRegex(
             UserWarning,
-            r"\d+ missing covariates in group. Creating a distinct covariate per batch for the missing values. You may want to double check your covariates.",
+            r"2 missing covariates in covar_mod. Creating a distinct covariate per batch for the missing values. You may want to double check your covariates.",
         ):
-            res = pycombat_seq(self.y, self.batch, group=[1, np.nan, 1, np.nan])
+            res = pycombat_seq(self.y, self.batch, covar_mod=[1, np.nan, 1, np.nan])
         self.assertTrue(np.array_equal(res, ref))

--- a/tests/pycombat/test_pycombatseq.py
+++ b/tests/pycombat/test_pycombatseq.py
@@ -1,5 +1,6 @@
 import unittest
 import numpy as np
+import pytest
 
 from inmoose.utils import rnbinom
 from inmoose.pycombat import pycombat_seq
@@ -7,35 +8,35 @@ from inmoose.pycombat import pycombat_seq
 
 class test_pycombatseq(unittest.TestCase):
     def setUp(self):
-        y = np.array(rnbinom(80, size=5, mu=20, seed=42)).reshape((20, 4))
-        self.y = np.vstack(([0, 0, 0, 0], [0, 0, 2, 2], y))
-        self.batch = np.array([1, 1, 2, 2])
+        y = np.array(rnbinom(100, size=5, mu=20, seed=42)).reshape((20, 5))
+        self.y = np.vstack(([0, 0, 0, 0, 0], [0, 0, 2, 2, 2], y))
+        self.batch = np.array([1, 1, 2, 2, 2])
 
     def test_pycombat_seq(self):
         ref = np.array(
             [
-                [0, 0, 0, 0],
-                [0, 0, 2, 2],
-                [24, 14, 15, 26],
-                [10, 18, 11, 17],
-                [5, 30, 35, 6],
-                [22, 14, 16, 19],
-                [25, 20, 27, 20],
-                [12, 38, 19, 23],
-                [17, 16, 18, 15],
-                [10, 30, 11, 26],
-                [28, 18, 17, 29],
-                [13, 22, 16, 20],
-                [31, 12, 13, 35],
-                [21, 22, 25, 20],
-                [27, 18, 20, 26],
-                [26, 32, 30, 30],
-                [15, 18, 16, 18],
-                [9, 42, 41, 9],
-                [40, 20, 45, 19],
-                [38, 30, 42, 28],
-                [25, 23, 21, 29],
-                [18, 21, 22, 18],
+                [0, 0, 0, 0, 0],
+                [0, 0, 2, 2, 2],
+                [21, 14, 14, 26, 14],
+                [24, 13, 15, 13, 28],
+                [29, 5, 13, 3, 30],
+                [30, 20, 16, 33, 26],
+                [12, 36, 31, 26, 8],
+                [10, 20, 17, 8, 24],
+                [18, 31, 34, 24, 18],
+                [23, 14, 22, 15, 19],
+                [32, 15, 11, 32, 33],
+                [27, 15, 15, 30, 17],
+                [25, 28, 20, 25, 36],
+                [28, 14, 26, 15, 18],
+                [12, 47, 36, 6, 42],
+                [23, 39, 15, 44, 34],
+                [31, 20, 26, 24, 26],
+                [29, 17, 21, 26, 18],
+                [37, 20, 14, 37, 33],
+                [21, 19, 13, 28, 21],
+                [23, 14, 16, 14, 25],
+                [13, 33, 16, 45, 11],
             ]
         )
         res = pycombat_seq(self.y, self.batch)
@@ -43,31 +44,31 @@ class test_pycombatseq(unittest.TestCase):
 
         ref = np.array(
             [
-                [0, 0, 0, 0],
-                [0, 0, 2, 2],
-                [18, 13, 16, 34],
-                [9, 15, 12, 21],
-                [15, 36, 27, 2],
-                [23, 11, 19, 20],
-                [27, 20, 26, 19],
-                [9, 40, 25, 25],
-                [17, 16, 18, 15],
-                [7, 29, 19, 25],
-                [25, 15, 21, 33],
-                [12, 20, 17, 22],
-                [17, 11, 15, 60],
-                [22, 24, 24, 18],
-                [27, 16, 23, 26],
-                [26, 32, 31, 31],
-                [14, 17, 16, 19],
-                [10, 53, 33, 8],
-                [46, 24, 38, 16],
-                [40, 34, 40, 25],
-                [22, 21, 22, 33],
-                [19, 21, 22, 17],
+                [0, 0, 0, 0, 0],
+                [0, 0, 2, 2, 2],
+                [19, 14, 14, 29, 13],
+                [22, 13, 15, 13, 30],
+                [34, 2, 15, 8, 25],
+                [24, 18, 17, 41, 24],
+                [11, 43, 24, 25, 12],
+                [14, 21, 16, 7, 23],
+                [31, 39, 29, 19, 10],
+                [28, 18, 18, 12, 17],
+                [17, 12, 11, 45, 47],
+                [24, 14, 16, 33, 17],
+                [24, 26, 20, 22, 42],
+                [34, 18, 21, 13, 16],
+                [6, 67, 33, 10, 35],
+                [19, 31, 20, 51, 33],
+                [34, 23, 23, 21, 24],
+                [30, 18, 19, 26, 16],
+                [32, 17, 19, 38, 32],
+                [17, 16, 14, 36, 20],
+                [23, 14, 15, 13, 25],
+                [8, 30, 18, 49, 15],
             ]
         )
-        res = pycombat_seq(self.y, self.batch, covar_mod=[1, 1, 1, 2])
+        res = pycombat_seq(self.y, self.batch, covar_mod=[1, 1, 1, 2, 2])
         self.assertTrue(np.array_equal(res, ref))
 
         # test with reference batch
@@ -80,14 +81,40 @@ class test_pycombatseq(unittest.TestCase):
         self.assertFalse(np.array_equal(res[:, non_ref_col], self.y[:, non_ref_col]))
 
         # also test with non-integer batch ids
-        res2 = pycombat_seq(self.y, ["a", "a", "b", "b"], ref_batch="a")
+        res2 = pycombat_seq(self.y, ["a", "a", "b", "b", "b"], ref_batch="a")
         self.assertTrue(np.array_equal(res, res2))
 
         # test with incomplete group
-        ref = pycombat_seq(self.y, self.batch, covar_mod=[1, 2, 1, 3])
+        with self.assertRaisesRegex(
+            ValueError,
+            expected_regex="2 values are missing in covariates col_0. Correct your covariates or use the cov_missing_value parameters",
+        ):
+            res = pycombat_seq(self.y, self.batch, covar_mod=[1, np.nan, 1, np.nan, 1])
+
+        ref = pycombat_seq(self.y, self.batch, covar_mod=[1, 2, 1, 3, 1])
         with self.assertWarnsRegex(
             UserWarning,
-            r"2 missing covariates in covar_mod. Creating a distinct covariate per batch for the missing values. You may want to double check your covariates.",
+            r"1 missing covariates in covar_mod. Creating a distinct covariate per batch for the missing values. You may want to double check your covariates.",
         ):
-            res = pycombat_seq(self.y, self.batch, covar_mod=[1, np.nan, 1, np.nan])
+            res = pycombat_seq(
+                self.y,
+                self.batch,
+                covar_mod=[1, 2, 1, np.nan, 1],
+                cov_missing_value="fill",
+            )
+        self.assertTrue(np.array_equal(res, ref))
+
+        with self.assertWarnsRegex(
+            UserWarning,
+            r"1 samples with missing covariates in covar_mod. They are removed from the data. You may want to double check your covariates.",
+        ):
+            res = pycombat_seq(
+                self.y,
+                self.batch,
+                covar_mod=[1, 2, 1, np.nan, 1],
+                cov_missing_value="remove",
+            )
+        ref_y = np.delete(self.y, (3), axis=1)
+        ref_batch = np.array([1, 1, 2, 2])
+        ref = pycombat_seq(ref_y, ref_batch, covar_mod=[1, 2, 1, 1])
         self.assertTrue(np.array_equal(res, ref))

--- a/tests/pycombat/test_pycombatseq.py
+++ b/tests/pycombat/test_pycombatseq.py
@@ -1,6 +1,5 @@
 import unittest
 import numpy as np
-import pytest
 
 from inmoose.utils import rnbinom
 from inmoose.pycombat import pycombat_seq
@@ -84,12 +83,18 @@ class test_pycombatseq(unittest.TestCase):
         res2 = pycombat_seq(self.y, ["a", "a", "b", "b", "b"], ref_batch="a")
         self.assertTrue(np.array_equal(res, res2))
 
+        # test raise error for single sample batch
+        with self.assertRaisesRegex(
+            ValueError, expected_regex="pycombat_seq doesn't support 1 sample per batch"
+        ):
+            pycombat_seq(self.y, [1, 2, 2, 2, 2])
+
         # test with incomplete group
         with self.assertRaisesRegex(
             ValueError,
             expected_regex="2 values are missing in covariates col_0. Correct your covariates or use the cov_missing_value parameters",
         ):
-            res = pycombat_seq(self.y, self.batch, covar_mod=[1, np.nan, 1, np.nan, 1])
+            pycombat_seq(self.y, self.batch, covar_mod=[1, np.nan, 1, np.nan, 1])
 
         ref = pycombat_seq(self.y, self.batch, covar_mod=[1, 2, 1, 3, 1])
         with self.assertWarnsRegex(


### PR DESCRIPTION
### What?
- Add a function that will format the `covar_mod` as needed to create the design matrix.
- Manage NaN in `covar_mod` parameter, following `cov_missing_value` parameter 
- Simplify the `make_design_matrix` function. 
- Add error message for single sample batch 

### How? 
In the previous version, the input data for the `covar_mod` parameter it must have been a matrix containing only integer categorical variables.
Here we implement the `format_covar_mod` function that 
- formats the `covar_mod` parameter according to the needs of design matrix creation, and allows the user to use different data types and formats (list, np array, dataframe with non-integer categorical variables).
- Identify continue variables and raise an error 
- Handle missing covariates in pycombat(-seq), to have the choice between 3 possibility:
    - Default: Stop the code and raise an error + explain the possibility 
    - Remove samples with missing covariates and raise a warning 
    - Create a distinct covariate per batch where a missing covariate appears (actual implementation in pycombat) and raise a warning 

Removal of `group` and `full_mod` parameters from the `make_design_matrix` function. 
These two parameters were used to add vector covariates, which is no longer necessary once the `covar_mod` parameter has been set to the correct format.