### PR TITLE
Improve check input message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Fix issue #25 and #10 related to counts parameter data format check and gestion (when it's a pandas dataframe)
 - add DESeq2 variance stabilizing transformation to the `deseq2` package
+- improve the error message for confounding variable in `pycombat` package
 
 ## [0.3.0]
 

--- a/inmoose/pycombat/covariates.py
+++ b/inmoose/pycombat/covariates.py
@@ -257,7 +257,7 @@ class VirtualCohortInput:
 
         if self.confounded_cov is not None and len(self.confounded_cov) > 0:
             raise ValueError(
-                f"Covariates {', '.join([str(c) for c in self.confounded_cov])} are confounded with the batches. Please review your covariates before proceeding with batch effect correction."
+                f"Covariates {', '.join([str(self.covar_mod.design_info.column_names[c]) for c in self.confounded_cov])} are confounded with the batches. Please review your covariates before proceeding with batch effect correction."
             )
         return (False, self)
 

--- a/tests/pycombat/test_pycombatseq.py
+++ b/tests/pycombat/test_pycombatseq.py
@@ -189,6 +189,32 @@ class test_pycombatseq(unittest.TestCase):
         )
         self.assertTrue(np.array_equal(res, res2))
 
+        # check confounded covariates
+        with self.assertRaisesRegex(
+            ValueError,
+            expected_regex=r"Covariates test are confounded with the batches. Please review your covariates before proceeding with batch effect correction.",
+        ):
+            pycombat_seq(
+                self.y,
+                self.batch,
+                covar_mod=pd.DataFrame(
+                    [2, 2, 1, 1, 1],
+                    columns=["test"],
+                ),
+            )
+
+        with self.assertRaisesRegex(
+            ValueError,
+            expected_regex=r"Covariates cov_0 are confounded with the batches. Please review your covariates before proceeding with batch effect correction.",
+        ):
+            pycombat_seq(
+                self.y,
+                self.batch,
+                covar_mod=pd.DataFrame(
+                    [2, 2, 1, 1, 1],
+                ),
+            )
+
         with self.assertWarnsRegex(
             UserWarning,
             r"1 samples with missing covariates in covar_mod. They are removed from the data. You may want to double check your covariates.",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Also link to the corresponding Jira card in the Title -->
<!--- e.g. "MCB-123-456 add a feature to cure cancer" -->

## Description
Improving the error message in the case of confounding covariable in pycombat 
<!--- Describe your changes in detail. -->
<!--- If it is a feature change, describe the new behavior. -->

## Motivation and Context
The previous message return only index of the confounding columns in design matrix, that not always correspond exactly to columns of the covariates matrix give in input. We want in the error message the confounding variable name 
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] No code (non-breaking change that does not impact code: formatting, build system, documentation...)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My changes are in a separate branch named after a Jira card, or -- if not applicable -- with a descriptive name.
- [x] I have descriptive commit messages, with a short title (first line).
- [x] I have added and/or updated tests to reflect my changes.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have updated the [Changelog](../CHANGELOG.md).
- [x] My code and documentation follow the [numpy docstring format](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_numpy.html).
- [ ] I have reviewed possible licensing issues, preferably with a person in charge of the topic.
