### PR TITLE
Add R-like functions for fitting linear models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - add experimental support for MSVC compiler
 - add R-like functions for fitting linear models in module `utils`
+- add a function to compute natural cubic spines basis in module `utils`
 
 ## [0.4.1]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [0.4.2-dev]
 
 - add experimental support for MSVC compiler
+- add R-like functions for fitting linear models in module `utils`
 
 ## [0.4.1]
 

--- a/inmoose/utils/__init__.py
+++ b/inmoose/utils/__init__.py
@@ -1,2 +1,3 @@
 from .factor import Factor, gl, asfactor
+from .lm import lm_fit, lm_wfit
 from .stats import rnbinom, dnbinom_mu, dnorm, pnorm, pt

--- a/inmoose/utils/__init__.py
+++ b/inmoose/utils/__init__.py
@@ -1,3 +1,4 @@
 from .factor import Factor, gl, asfactor
 from .lm import lm_fit, lm_wfit
+from .splines import ns, spline_design
 from .stats import rnbinom, dnbinom_mu, dnorm, pnorm, pt

--- a/inmoose/utils/lm.py
+++ b/inmoose/utils/lm.py
@@ -1,0 +1,141 @@
+# -----------------------------------------------------------------------------
+# Copyright (C) 2024 Maximilien Colange
+
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# -----------------------------------------------------------------------------
+
+import numpy as np
+from statsmodels.regression.linear_model import WLS
+
+
+class lm_wfit:
+    """
+    Python equivalent to R lm.wfit
+
+    This class is merely a wrapper around :class:`RegressionResults`, the
+    return type of :meth:`OLS.fit` and :meth:`WLS.fit`.
+
+    It contains the solution to the equation A X = B, where A is a known
+    matrix, B a known vector and X the unknown to solve for. The solution is
+    obtained by a weighted least-square-error fit based on the QR-decomposition of A.
+
+    Arguments
+    ---------
+    design : array_like
+        matrix A of the equation
+    b : array_like
+        offset (vector B in the equation)
+    w : array_like
+        weights to use in the least-square-error fit
+
+    Attributes
+    ----------
+    coefficients : ndarray
+        the value found for X
+    residuals : ndarray
+        the residuals, i.e. the difference between A X and B
+    fitted_values : ndarray
+        the value A X
+    effects : ndarray
+        vector of orthogonal single-df effects. The first :code:`rank` of them
+        correspond to the :code:`coefficients`
+    weights : ndarray
+        the weights used in the least-square-error fit
+    rank : int
+        the column rank of matrix A
+    df_residuals : ndarray
+        degrees of freedom of residuals
+    qr : ndarray, ndarray
+        the QR decomposition of matrix A
+    """
+
+    def __init__(self, design, b, w):
+        self.fit = WLS(b, design, w).fit(method="qr")
+        self._effects = None
+
+    @property
+    def coefficients(self):
+        return self.fit.params
+
+    @property
+    def residuals(self):
+        return self.fit.resid
+
+    @property
+    def fitted_values(self):
+        return self.fit.fittedvalues
+
+    @property
+    def effects(self):
+        if self._effects is None:
+            Q, _ = np.linalg.qr(self.fit.model.wexog, mode="complete")
+            self._effects = Q.T @ self.fit.model.wendog
+        return self._effects
+
+    @property
+    def weights(self):
+        return self.fit.weights
+
+    @property
+    def rank(self):
+        return self.fit.model.rank
+
+    @property
+    def df_residuals(self):
+        return self.fit.model.df_resid
+
+    @property
+    def qr(self):
+        return self.fit.model.exog_Q, self.fit.model.exog_R
+
+
+class lm_fit(lm_wfit):
+    """
+    Python equivalent to R lm.fit
+
+    This class is merely a wrapper around :class:`RegressionResults`, the
+    return type of :meth:`OLS.fit` and :meth:`WLS.fit`.
+
+    It contains the solution to the equation A X = B, where A is a known
+    matrix, B a known vector and X the unknown to solve for. The solution is
+    obtained by a least-square-error fit based on the QR-decomposition of A.
+
+    Arguments
+    ---------
+    design : array_like
+        matrix A of the equation
+    b : array_like
+        offset (vector B in the equation)
+
+    Attributes
+    ----------
+    coefficients : ndarray
+        the value found for X
+    residuals : ndarray
+        the residuals, i.e. the difference between A X and B
+    fitted_values : ndarray
+        the value A X
+    effects : ndarray
+        vector of orthogonal single-df effects. The first :code:`rank` of them
+        correspond to the :code:`coefficients`
+    rank : int
+        the column rank of matrix A
+    df_residuals : ndarray
+        degrees of freedom of residuals
+    qr : ndarray, ndarray
+        the QR decomposition of matrix A
+    """
+
+    def __init__(self, design, b):
+        super().__init__(design, b, 1.0)

--- a/inmoose/utils/splines.py
+++ b/inmoose/utils/splines.py
@@ -1,0 +1,206 @@
+# -----------------------------------------------------------------------------
+# Copyright (C) 2024 Maximilien Colange
+
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# -----------------------------------------------------------------------------
+
+# original code was contributed to StackOverflow: https://stackoverflow.com/questions/71550468/does-python-have-an-analogue-to-rs-splinesns
+# code was improved to better match the R code
+
+# As per StackOverflow terms of service (see https://stackoverflow.com/help/licensing), original code is licensed under CC BY SA 4.0, which is compatible with GPL3 (see https://creativecommons.org/2015/10/08/cc-by-sa-4-0-now-one-way-compatible-with-gplv3/)
+
+import logging
+import numpy as np
+from scipy.interpolate import splev
+
+
+def spline_design(knots, x, order, derivs=0):
+    """
+    Evaluate the design matrix for the B-splines defined by :code:`knots` at the values in :code:`x`.
+
+    Arguments
+    ---------
+    knots : array_like
+        vector of knot positions (which will be sorted increasingly if needed).
+    x : array_like
+        vector of values at which to evaluate the B-spline functions or
+        derivatives. The values in x must be between the “inner” knots
+        :code:`knots[ord]` and :code:`knots[ length(knots) - (ord-1)]`
+    order : int
+        a positive integer giving the order of the spline function. This is the
+        number of coefficients in each piecewise polynomial segment, thus a
+        cubic spline has order 4.
+    derivs : array_like
+        an integer vector with values between 0 and :code:`ord` - 1,
+        conceptually recycled to the length of :code:`x`. The derivative of the
+        given order is evaluated at the :code:`x` positions. Defaults to zero.
+
+    Returns
+    -------
+    ndarray
+        a matrix with :code:`len(x)` rows and :code:`len(knots) - ord` columns.
+        The :code:`i`'th row of the matrix contains the coefficients of the
+        B-splines (or the indicated derivative of the B-splines) defined by the
+        knot vector and evaluated at the :code:`i`'th value of :code:`x`. Each
+        B-spline is defined by a set of :code:`ord` successive knots so the
+        total number of B-splines is :code:`len(knots) - ord`.
+    """
+    derivs = np.asarray(derivs)
+    if derivs.ndim == 0:
+        der = np.repeat(derivs, len(x))
+    else:
+        der = np.zeros(len(x), dtype=int)
+        der[: len(derivs)] = derivs
+    n_bases = len(knots) - order
+    res = np.empty((len(x), n_bases), dtype=float)
+    for i in range(n_bases):
+        coefs = np.zeros((n_bases,))
+        coefs[i] = 1
+        for j in range(len(x)):
+            res[j, i] = splev(x, (knots, coefs, order - 1), der=der[j])[j]
+    return res
+
+
+class ns:
+    """
+    Class storing the B-spline basis matrix for a natural cubic spline and info used to generate it.
+
+    Attributes
+    ----------
+    knots : array_like
+        breakpoints that define the spline.
+    include_intercept : bool
+        whether an intercept is included in the basis
+    boundary_knots : array_like
+        boundary points at which to impose the natural boundary conditions and
+        anchor the B-spline basis.
+    basis : ndarray
+        a matrix of dimension :code:`(len(x), df)`, where :code:`df =
+        len(knots)-1-intercept` if :code:`df` was not supplied.
+    """
+
+    def __init__(
+        self, x, df=None, knots=None, boundary_knots=None, include_intercept=False
+    ):
+        """
+        Generate the B-spline basis matrix for a natural cubic spline.
+
+        This function intends to provide the same functionality as R splines::ns.
+
+        Arguments
+        ---------
+        x : array_like
+            the predictor variable
+        df : int, optional
+            degrees of freedom. If :code:`knots` is not specified, then the
+            function chooses :code:`df - 1 - intercept` knots at suitably chosen
+            quantiles of :code:`x`. If :code:`None`, the number of inner knots is
+            set to :code:`len(knots)`.
+        knots : array_like, optional
+            breakpoints that define the spline. The default is no knots; together
+            with the natural boundary conditions this results in a basis for linear
+            regression on :code:`x`. Typical values are the mean or median for one
+            knot, quantiles for more knots. See also :code:`boundary_knots`.
+        include_intercept : bool, optional
+            if :code:`True`, an intercept is included in the basis; default is
+            :code:`False`.
+        boundary_knots : array_like, optional
+            boundary points at which to impose the natural boundary conditions and
+            anchor the B-spline basis (default the range of the data). If both
+            :code:`knots` and :code:`boundary_knots` are supplied, the basis
+            parameters do not depend on :code:`x`. Data can extend beyond
+            :code:`boundary_knots`.
+
+        Returns
+        -------
+        ndarray
+            a matrix of dimension :code:`(len(x), df)`, where :code:`df =
+            len(knots)-1-intercept` if :code:`df` was not supplied.
+        """
+        self.include_intercept = include_intercept
+        x = np.asarray(x)
+        if boundary_knots is None:
+            boundary_knots = [np.min(x), np.max(x)]
+            outside = False
+        else:
+            boundary_knots = list(np.sort(boundary_knots))
+            out_left = x < boundary_knots[0]
+            out_right = x > boundary_knots[1]
+            outside = out_left | out_right
+        self.boundary_knots = boundary_knots
+
+        if df is not None and knots is None:
+            nIknots = df - 1 - include_intercept
+            if nIknots < 0:
+                nIknots = 0
+                logging.warnings.warn("df was too small, used {1+include_intercept}")
+
+            if nIknots > 0:
+                knots = np.linspace(0, 1, num=nIknots + 2)[1:-1]
+                knots = np.quantile(x, knots)
+        else:
+            nIknots = len(knots)
+        self.knots = knots
+
+        Aknots = np.sort(np.concatenate((boundary_knots * 4, knots)))
+
+        if np.any(outside):
+            basis = np.empty((x.shape[0], nIknots + 4), dtype=float)
+            if np.any(out_left):
+                k_pivot = boundary_knots[0]
+                xl = np.ones((np.sum(out_left), 2))
+                xl[:, 1] = x[out_left] - k_pivot
+                tt = spline_design(Aknots, [k_pivot, k_pivot], 4, [0, 1])
+                basis[out_left, :] = xl @ tt
+            if np.any(out_right):
+                k_pivot = boundary_knots[1]
+                xr = np.ones((np.sum(out_right), 2))
+                xr[:, 1] = x[out_right] - k_pivot
+                tt = spline_design(Aknots, [k_pivot, k_pivot], 4, [0, 1])
+                basis[out_right, :] = xr @ tt
+            inside = ~outside
+            if np.any(inside):
+                basis[inside, :] = spline_design(Aknots, x[inside], 4)
+        else:
+            basis = spline_design(Aknots, x, 4)
+
+        const = spline_design(Aknots, boundary_knots, 4, [2, 2])
+
+        if include_intercept is False:
+            basis = basis[:, 1:]
+            const = const[:, 1:]
+
+        qr_const = np.linalg.qr(const.T, mode="complete")[0]
+        self.basis = (qr_const.T @ basis.T).T[:, 2:]
+
+    def predict(self, newx):
+        """
+        Evaluate the spline basis at given values
+
+        Arguments
+        ---------
+        newx : ndarray
+            new predictor variable to regenerate the spline from
+
+        Returns
+        -------
+        ns
+            a new natural spline object, evaluated at the given values
+        """
+        return ns(
+            newx,
+            knots=self.knots,
+            boundary_knots=self.boundary_knots,
+            include_intercept=self.include_intercept,
+        )

--- a/tests/utils/test_lm.py
+++ b/tests/utils/test_lm.py
@@ -1,0 +1,38 @@
+import unittest
+import numpy as np
+
+from inmoose.utils import lm_fit, lm_wfit
+
+
+class Test(unittest.TestCase):
+
+    def assertArrayEqual(self, x, y, tol=1e-6):
+        self.assertTrue(np.allclose(x, y, atol=tol))
+
+    def test_lm_fit(self):
+        res = lm_fit(
+            np.arange(5, 11).reshape(3, 2), np.array([1.0 / 30, 1.0 / 31, 1.0 / 32])
+        )
+        self.assertArrayEqual(res.coefficients, np.array([-0.03644713, 0.03592630]))
+        self.assertArrayEqual(
+            res.residuals, [1.120072e-05, -2.240143e-05, 1.120072e-05]
+        )
+        self.assertArrayEqual(res.fitted_values, [0.03332213, 0.03228047, 0.03123880])
+        self.assertArrayEqual(res.effects, [-5.411474e-02, 1.413684e-02, 2.743604e-05])
+        self.assertEqual(res.rank, 2)
+        self.assertArrayEqual(res.df_residuals, [1])
+
+    def test_lm_wfit(self):
+        res = lm_wfit(
+            np.arange(5, 11).reshape(3, 2),
+            np.array([1.0 / 30, 1.0 / 31, 1.0 / 32]),
+            np.array([100, 50, 1]),
+        )
+        self.assertArrayEqual(res.coefficients, np.array([-0.03654927, 0.03601318]))
+        self.assertArrayEqual(
+            res.residuals, [6.165532e-07, -2.466213e-06, 6.165532e-05]
+        )
+        self.assertArrayEqual(res.fitted_values, [0.03333272, 0.03226053, 0.03118834])
+        self.assertArrayEqual(res.effects, [-3.981168e-01, 7.496570e-02, 6.437005e-05])
+        self.assertEqual(res.rank, 2)
+        self.assertArrayEqual(res.df_residuals, [1])

--- a/tests/utils/test_splines.py
+++ b/tests/utils/test_splines.py
@@ -1,0 +1,50 @@
+import unittest
+import numpy as np
+
+from inmoose.utils import ns, spline_design
+
+
+class Test(unittest.TestCase):
+
+    def test_splineDesign(self):
+        spline = spline_design(np.arange(10), [4.5, 5, 5.5], 4)
+        self.assertTrue(
+            np.allclose(
+                spline,
+                np.array(
+                    [
+                        [0, 0.02083333, 0.47916667, 0.4791667, 0.02083333, 0.0],
+                        [0, 0.00000000, 0.16666667, 0.6666667, 0.16666667, 0.00000000],
+                        [0, 0.00000000, 0.02083333, 0.4791667, 0.47916667, 0.02083333],
+                    ]
+                ),
+            )
+        )
+
+    def test_splines(self):
+        res = ns([1, 2, 3, 4, 5, 6], df=3, include_intercept=True)
+        self.assertTrue(
+            np.allclose(
+                res.basis,
+                [
+                    [-0.45528153, 0.5915984, -0.39439896],
+                    [0.04538466, 0.4796729, -0.30911524],
+                    [0.39866939, 0.3936580, -0.17710530],
+                    [0.46333206, 0.3583848, 0.04641015],
+                    [0.23937270, 0.3738533, 0.36143111],
+                    [-0.13196814, 0.4152326, 0.72317830],
+                ],
+            )
+        )
+
+        res2 = res.predict(newx=[70, 81, 92])
+        self.assertTrue(
+            np.allclose(
+                res2.basis,
+                [
+                    [-25.46985, 3.339883, 24.37341],
+                    [-29.82480, 3.842558, 28.43829],
+                    [-34.17975, 4.345232, 32.50318],
+                ],
+            )
+        )


### PR DESCRIPTION
## Description
This PR adds functions that behave like R `lm.fit` and `lm.wfit`.
They are merely wrappers around linear models fits from `statsmodels`, but provide quality-of-life improvement for users familiar with the R functions.

## Motivation and Context
This PR adds useful functions to later port `limma` fit functions.
See [the corresponding Jira card](https://epigenelabsteam.atlassian.net/browse/CR-263).

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] No code (non-breaking change that does not impact code: formatting, build system, documentation...)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My changes are in a separate branch named after a Jira card, or -- if not applicable -- with a descriptive name.
- [x] I have descriptive commit messages, with a short title (first line).
- [x] I have added and/or updated tests to reflect my changes.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have updated the [Changelog](../CHANGELOG.md).
- [x] My code and documentation follow the [numpy docstring format](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_numpy.html).
- [x] I have reviewed possible licensing issues, preferably with a person in charge of the topic.
