### PR TITLE
fix row and columns name for dataframe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [0.5.1-dev]
 
-None
+- fix pycombat covariates action remove with count dataframe output 
 
 ## [0.5.0]
 

--- a/inmoose/pycombat/covariates.py
+++ b/inmoose/pycombat/covariates.py
@@ -252,7 +252,7 @@ class VirtualCohortInput:
             counts, batch, covar, list_samples, list_genes = self.fix_na_cov(
                 na_cov_action
             )
-            if self.dataframe_instance == True:
+            if self.dataframe_instance:
                 counts = pd.DataFrame(counts, index=list_genes, columns=list_samples)
             if self.ref_batch_idx is not None:
                 ref_batch = self.batch[self.ref_batch_idx]
@@ -309,7 +309,7 @@ class VirtualCohortInput:
                 f"{(nan_covar_mod.sum(axis=1)>0).sum()} samples with missing covariates in covar_mod. They are removed from the data. You may want to double check your covariates."
             )
             keep = nan_covar_mod.sum(axis=1) == 0
-            if self.dataframe_instance == True:
+            if self.dataframe_instance:
                 list_samples = self.list_samples[keep]
             else:
                 list_samples = None

--- a/inmoose/pycombat/covariates.py
+++ b/inmoose/pycombat/covariates.py
@@ -85,12 +85,15 @@ class VirtualCohortInput:
             list_samples = counts.columns
             list_genes = counts.index
             counts = counts.values
+            dataframe_instance = True
         elif isinstance(counts, np.ndarray):
             list_samples = None
             list_genes = None
+            dataframe_instance = False
         else:
             raise ValueError("counts must be a pandas DataFrame or a numpy nd array")
 
+        self.dataframe_instance = dataframe_instance
         self.list_samples = list_samples
         self.list_genes = list_genes
         self.counts = counts
@@ -246,7 +249,11 @@ class VirtualCohortInput:
             )
 
         if self.nan_cov > 0:
-            counts, batch, covar = self.fix_na_cov(na_cov_action)
+            counts, batch, covar, list_samples, list_genes = self.fix_na_cov(
+                na_cov_action
+            )
+            if self.dataframe_instance == True:
+                counts = pd.DataFrame(counts, index=list_genes, columns=list_samples)
             if self.ref_batch_idx is not None:
                 ref_batch = self.batch[self.ref_batch_idx]
             else:
@@ -302,7 +309,17 @@ class VirtualCohortInput:
                 f"{(nan_covar_mod.sum(axis=1)>0).sum()} samples with missing covariates in covar_mod. They are removed from the data. You may want to double check your covariates."
             )
             keep = nan_covar_mod.sum(axis=1) == 0
-            return self.counts[:, keep], self.batch[keep], self.covar_mod[keep]
+            if self.dataframe_instance == True:
+                list_samples = self.list_samples[keep]
+            else:
+                list_samples = None
+            return (
+                self.counts[:, keep],
+                self.batch[keep],
+                self.covar_mod[keep],
+                list_samples,
+                self.list_genes,
+            )
         elif na_cov_action == "fill":
             logging.warnings.warn(
                 f"{nan_covar_mod.sum().sum()} missing covariates in covar_mod. Creating a distinct covariate per batch for the missing values. You may want to double check your covariates."
@@ -352,7 +369,13 @@ class VirtualCohortInput:
                     covar_mod[col] = covar_mod[col].astype(str)
                 for i, j in enumerate(np.where(nan_cov_col)[0]):
                     covar_mod.loc[j, col] = nan_batch_group[i]
-            return self.counts, self.batch, covar_mod
+            return (
+                self.counts,
+                self.batch,
+                covar_mod,
+                self.list_samples,
+                self.list_genes,
+            )
         else:
             raise ValueError(
                 f"unknown value {na_cov_action} for argument 'na_cov_action': must be one of 'raise', 'remove' or 'fill'"

--- a/inmoose/pycombat/pycombat_norm.py
+++ b/inmoose/pycombat/pycombat_norm.py
@@ -220,9 +220,7 @@ def param_fun(
     Returns:
         array list -- estimated adjusted additive and multiplicative batch effect
     """
-    if (
-        mean_only
-    ):  # if mean_only, no need for complex method: batch effect is immediately calculated
+    if mean_only:  # if mean_only, no need for complex method: batch effect is immediately calculated
         t2_n = np.multiply(t2[i], 1)
         t2_n_g_hat = np.multiply(t2_n, gamma_hat[i])
         gamma_star = postmean(

--- a/inmoose/pycombat/pycombat_norm.py
+++ b/inmoose/pycombat/pycombat_norm.py
@@ -616,7 +616,7 @@ def pycombat_norm(
         dat,
     )
 
-    if dataframe_instance == True:
+    if dataframe_instance:
         return pd.DataFrame(bayes_data, columns=list_samples, index=list_genes)
     else:
         return bayes_data

--- a/inmoose/pycombat/pycombat_norm.py
+++ b/inmoose/pycombat/pycombat_norm.py
@@ -220,7 +220,9 @@ def param_fun(
     Returns:
         array list -- estimated adjusted additive and multiplicative batch effect
     """
-    if mean_only:  # if mean_only, no need for complex method: batch effect is immediately calculated
+    if (
+        mean_only
+    ):  # if mean_only, no need for complex method: batch effect is immediately calculated
         t2_n = np.multiply(t2[i], 1)
         t2_n_g_hat = np.multiply(t2_n, gamma_hat[i])
         gamma_star = postmean(
@@ -580,6 +582,7 @@ def pycombat_norm(
         counts, batch, covar_mod, ref_batch, na_cov_action=na_cov_action
     )
 
+    dataframe_instance = vci.dataframe_instance
     dat = vci.counts
     list_samples = vci.list_samples
     list_genes = vci.list_genes
@@ -615,7 +618,7 @@ def pycombat_norm(
         dat,
     )
 
-    if isinstance(counts, pd.DataFrame):
+    if dataframe_instance == True:
         return pd.DataFrame(bayes_data, columns=list_samples, index=list_genes)
     else:
         return bayes_data

--- a/inmoose/pycombat/pycombat_seq.py
+++ b/inmoose/pycombat/pycombat_seq.py
@@ -227,7 +227,7 @@ def pycombat_seq(
     adjust_counts_whole[keep, :] = adjust_counts
     adjust_counts_whole[rm, :] = countsOri[rm, :]
 
-    if dataframe_instance == True:
+    if dataframe_instance:
         return pd.DataFrame(adjust_counts_whole, columns=list_samples, index=list_genes)
     else:
         return adjust_counts_whole

--- a/inmoose/pycombat/pycombat_seq.py
+++ b/inmoose/pycombat/pycombat_seq.py
@@ -83,7 +83,7 @@ def pycombat_seq(
         ref_batch=ref_batch,
         na_cov_action=na_cov_action,
     )
-
+    dataframe_instance = vci.dataframe_instance
     counts = vci.counts
     list_samples = vci.list_samples
     list_genes = vci.list_genes
@@ -227,7 +227,7 @@ def pycombat_seq(
     adjust_counts_whole[keep, :] = adjust_counts
     adjust_counts_whole[rm, :] = countsOri[rm, :]
 
-    if isinstance(counts, pd.DataFrame):
+    if dataframe_instance == True:
         return pd.DataFrame(adjust_counts_whole, columns=list_samples, index=list_genes)
     else:
         return adjust_counts_whole

--- a/tests/pycombat/test_pycombatseq.py
+++ b/tests/pycombat/test_pycombatseq.py
@@ -188,7 +188,7 @@ class test_pycombatseq(unittest.TestCase):
                 index=["sample1", "sample2", "sample3", "sample5"],
             ),
         )
-        self.assertTrue(np.array_equal(res, res2))
+        pd.testing.assert_frame_equal(res, res2)
 
         # check confounded covariates
         with self.assertRaisesRegex(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fix the output of `pycombat_norm` and `pycombat_seq` when count is a dataframe and `na_cov_action = "remove"`

## Description and Context
<!-- Describe your changes here -->
<!-- Feel free to add sections if needed (e.g. "Test strategy" or "Compliance") -->
The output dataframe of `pycombat_norm` and `pycombat_seq` when count is a dataframe and `na_cov_action = "remove"` had no columns names and no row names, even if there are columns names and row names in the input dataframe. 
This PR fix the problem and implement one test 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] No code (non-breaking change that does not impact code: formatting, build system, documentation...)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Release (version number increment, possibly with documentation updates)

