### PR TITLE
CR-309 compatibility with numpy 2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## [0.5.2-dev]
 
-None
+- move most of C++ code to Python and Cython
+- compatibility with `numpy` 2.0.0
 
 ## [0.5.1]
 

--- a/inmoose/common_cpp/matrix.cpp
+++ b/inmoose/common_cpp/matrix.cpp
@@ -75,7 +75,7 @@ Matrix<T>::~Matrix()
 {
   if (owned)
   {
-    std::cerr << "[MATRIX] refcount = " << PyArray_REFCOUNT(obj) << std::endl;
+    std::cerr << "[MATRIX] refcount = " << Py_REFCNT(obj) << std::endl;
   }
 }
 

--- a/inmoose/deseq2/deseq2_cpp.py
+++ b/inmoose/deseq2/deseq2_cpp.py
@@ -991,15 +991,16 @@ def fitBeta(
             big_z_sqrt_w[:, :y_m] = z_sqrt_w.T
             # IRLS with Q matrix for X
             gamma_hat = np.swapaxes(q, -1, -2) @ big_z_sqrt_w[:, :, None]
-            beta_hat = np.linalg.solve(r, gamma_hat.squeeze(-1))
+            beta_hat = np.linalg.solve(r, gamma_hat).squeeze(-1)
         else:
             # use the standard design matrix and matrix inversion
             z = np.log(mu_hat_idx / nf[:, idx]) + (y[:, idx] - mu_hat_idx) / mu_hat_idx
             assert (x.T @ (x * w_vec.T[:, :, None]) + ridge).shape == (idx_n, x_p, x_p)
-            assert ((z * w_vec).T @ x).shape == (idx_n, x_p)
+            zwtx = (z * w_vec).T @ x
+            assert (zwtx).shape == (idx_n, x_p)
             beta_hat = np.linalg.solve(
-                x.T @ (x * w_vec.T[:, :, None]) + ridge, (z * w_vec).T @ x
-            )
+                x.T @ (x * w_vec.T[:, :, None]) + ridge, zwtx[:, :, None]
+            ).squeeze(-1)
 
         assert beta_hat.shape == (idx_n, x_p), f"{beta_hat.shape} vs {(idx_n, x_p)}"
         # easier to update beta_mat here instead than at the end of the loop

--- a/inmoose/edgepy/aveLogCPM.py
+++ b/inmoose/edgepy/aveLogCPM.py
@@ -181,7 +181,7 @@ def aveLogCPM(
     # Special case when all counts and library sizes are zero
     if _isAllZero(y):
         if (lib_size is None or max(lib_size) == 0) and (
-            offset is None or max(offset) == np.NINF
+            offset is None or max(offset) == -np.inf
         ):
             abundance = np.full((y.shape[0],), -np.log(y.shape[0]))
             return (abundance + np.log(1e6)) / np.log(2)

--- a/inmoose/edgepy/mglmOneGroup.py
+++ b/inmoose/edgepy/mglmOneGroup.py
@@ -107,7 +107,7 @@ def mglmOneGroup(
 
     # Check starting values
     if coef_start is None:
-        coef_start = np.NaN
+        coef_start = np.nan
     coef_start = np.full((y.shape[0],), coef_start, dtype="double")
 
     # Check weights

--- a/inmoose/pycombat/pycombat_norm.py
+++ b/inmoose/pycombat/pycombat_norm.py
@@ -347,7 +347,9 @@ def calculate_stand_mean(grand_mean, n_array, design, n_batch, B_hat):
     Returns:
         stand_mean {matrix} -- standardised mean
     """
-    stand_mean = np.dot(np.transpose(np.mat(grand_mean)), np.mat([1] * n_array))
+    stand_mean = np.dot(
+        np.transpose(np.asmatrix(grand_mean)), np.asmatrix([1] * n_array)
+    )
     # corrects the mean with design matrix information
     if design is not None:
         tmp = np.ndarray.copy(design)
@@ -369,7 +371,7 @@ def standardise_data(dat, stand_mean, var_pooled, n_array):
         s_data {matrix} -- standardised data matrix
     """
     s_data = (dat - stand_mean) / np.dot(
-        np.transpose(np.mat(np.sqrt(var_pooled))), np.mat([1] * n_array)
+        np.transpose(np.asmatrix(np.sqrt(var_pooled))), np.asmatrix([1] * n_array)
     )
     return s_data
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,5 +39,5 @@ doc = [
 ]
 
 [build-system]
-requires = ["setuptools", "numpy", "scipy", "Cython>=3.0.0", "wheel"]
+requires = ["setuptools", "numpy>=2.0.0", "scipy", "Cython>=3.0.0", "wheel"]
 

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,5 +1,5 @@
 [lint]
-extend-select = ["I"]
+extend-select = ["I", "NPY201"]
 
 [lint.per-file-ignores]
 "__init__.py" = ["E402"]

--- a/tests/edgepy/test_DGEList.py
+++ b/tests/edgepy/test_DGEList.py
@@ -15,15 +15,15 @@ class test_utils(unittest.TestCase):
         with self.assertRaisesRegex(
             ValueError, expected_regex="NaN counts are not allowed"
         ):
-            _isAllZero(np.array([1, 2, 3, np.NaN, 4, 5]))
+            _isAllZero(np.array([1, 2, 3, np.nan, 4, 5]))
         with self.assertRaisesRegex(
             ValueError, expected_regex="infinite counts are not allowed"
         ):
-            _isAllZero(np.array([1, 2, 3, np.PINF, 4, 5]))
+            _isAllZero(np.array([1, 2, 3, np.inf, 4, 5]))
         with self.assertRaisesRegex(
             ValueError, expected_regex="negative counts are not allowed"
         ):
-            _isAllZero(np.array([1, 2, 3, np.NINF, 4, 5]))
+            _isAllZero(np.array([1, 2, 3, -np.inf, 4, 5]))
         with self.assertRaisesRegex(
             ValueError, expected_regex="negative counts are not allowed"
         ):

--- a/tests/edgepy/test_mglm.py
+++ b/tests/edgepy/test_mglm.py
@@ -21,8 +21,8 @@ class test_mglm(unittest.TestCase):
         )
         ref1 = np.array(
             [
-                np.NINF,
-                np.NINF,
+                -np.inf,
+                -np.inf,
                 -2.986383,
                 -3.485387,
                 -2.896575,
@@ -53,7 +53,7 @@ class test_mglm(unittest.TestCase):
         )
         ref2 = np.array(
             [
-                np.NINF,
+                -np.inf,
                 -5.420406,
                 -3.273714,
                 -3.506488,


### PR DESCRIPTION
## Description and Context
See [CR-309].
`inmoose` is now built with `numpy` 2.0.0, and can be used with either pre- and post-2.0.0 `numpy` versions.

All modifications should be transparent for `inmoose` users.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] No code (non-breaking change that does not impact code: formatting, build system, documentation...)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Release (version number increment, possibly with documentation updates)



[CR-309]: https://epigenelabsteam.atlassian.net/browse/CR-309?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ