### PR TITLE
CR-354 inform coveralls.io that our pipeline has parallel jobs

### DIFF
--- a/.github/workflows/build_dist.yaml
+++ b/.github/workflows/build_dist.yaml
@@ -41,9 +41,21 @@ jobs:
         run: tox
 
       # upload the coverage report to coveralls.io
-      - name: Coveralls GitHub Action
+      - name: Upload coverage reports to Coveralls
         uses: coverallsapp/github-action@v2.3.0
+        with:
+          parallel: true
         if: ${{ matrix.python-version == '3.12' }}
+
+  finish_coverage:
+    needs: [tests_and_coverage]
+    name: Notify Coveralls that the parallel build has finished
+    runs-on: ubuntu-latest
+    steps:
+      - name: Close parallel build
+        uses: coverallsapp/github-action@v2.3.0
+        with:
+          parallel-finished: true
 
   build_sdist:
     needs: [ruff]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [0.7.1-dev]
 
 - fix a bug when splicing a `DEResults`
+- fix coverage report upload in CI/CD pipeline
 
 ## [0.7.0]
 


### PR DESCRIPTION
## Description and Context
See [CR-354]


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] No code (non-breaking change that does not impact code: formatting, build system, documentation...)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Release (version number increment, possibly with documentation updates)



[CR-354]: https://epigenelabsteam.atlassian.net/browse/CR-354?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ