### PR TITLE
allow arbitrary type for batch and group in `sim_rnaseq`

### DIFF
--- a/inmoose/sim/splat.py
+++ b/inmoose/sim/splat.py
@@ -25,6 +25,8 @@ import numpy as np
 from scipy.special import expit
 from scipy.stats import bernoulli, chi2, gamma, lognorm, poisson
 
+from ..utils import Factor
+
 
 def get_lognorm_factors(size, sel_prob, neg_prob, loc, scale, random_state):
     """
@@ -161,16 +163,16 @@ def sim_rnaseq(
 
     if batch is None:
         batch = np.zeros(nb_samples, dtype=np.int64)
-    batch = np.asarray(batch)
+    batch = Factor(batch)
     assert len(batch) == nb_samples
 
     if group is None:
         group = np.zeros(nb_samples, dtype=np.int64)
-    group = np.asarray(group)
+    group = Factor(group)
     assert len(group) == nb_samples
 
-    nb_batches = len(np.unique(batch))
-    nb_groups = len(np.unique(group))
+    nb_batches = batch.nlevels()
+    nb_groups = group.nlevels()
 
     # draw gene means
     original_means = gamma.rvs(
@@ -217,7 +219,7 @@ def sim_rnaseq(
         )
         for i in range(nb_groups)
     ]
-    de_lf = np.choose(group, [x[:, None] for x in de_lf])
+    de_lf = np.choose(group.codes, [x[:, None] for x in de_lf])
 
     # cell type specific cell means
     de_trended_cell_means = de_lf * trended_cell_means
@@ -229,7 +231,7 @@ def sim_rnaseq(
         )
         for i in range(nb_batches)
     ]
-    be_fact = np.choose(batch, [x[:, None] for x in be_fact])
+    be_fact = np.choose(batch.codes, [x[:, None] for x in be_fact])
     batch_cell_means = be_fact * de_trended_cell_means
 
     # counts

--- a/tests/sim/test_splat.py
+++ b/tests/sim/test_splat.py
@@ -4,6 +4,9 @@ from inmoose.sim.splat import sim_rnaseq
 
 N = 1000
 M = 10000
+batch = (M // 2) * ["A"] + (M // 2) * ["B"]
+group = (M // 4) * ["A"] + (M // 4) * ["B"]
+group = group + group
 
 
 class Test(unittest.TestCase):
@@ -13,6 +16,8 @@ class Test(unittest.TestCase):
         """
         data = sim_rnaseq(N, M, random_state=42)
         self.assertEqual(data.shape, (N, M))
+        data = sim_rnaseq(N, M, batch=batch)
+        data = sim_rnaseq(N, M, group=group)
 
     def test_sim_scrnaseq(self):
         """


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description and Context
See [CR-387]

`batch` and `group` arguments to function `sim_rnaseq` is limited to arrays of integers starting at 0. This PR allows passing arrays of arbitrary types instead.
The solution is to turn `batch` and `group` arguments to `Factor`s and use the underlying category indices in places where an integer array is required.
Also update the tests to check that the function no longer raises when passed `batch` and `group` arrays of string.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] No code (non-breaking change that does not impact code: formatting, build system, documentation...)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Release (version number increment, possibly with documentation updates)



[CR-387]: https://epigenelabsteam.atlassian.net/browse/CR-387?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ