### PR TITLE
harmonize _isAllZero behavior on dataframes and ndarrays

### DIFF
--- a/inmoose/edgepy/utils.py
+++ b/inmoose/edgepy/utils.py
@@ -1,6 +1,6 @@
 # -----------------------------------------------------------------------------
 # Copyright (C) 2008-2022 Yunshun Chen, Aaron TL Lun, Davis J McCarthy, Matthew E Ritchie, Belinda Phipson, Yifang Hu, Xiaobei Zhou, Mark D Robinson, Gordon K Smyth
-# Copyright (C) 2022-2023 Maximilien Colange
+# Copyright (C) 2022-2024 Maximilien Colange
 
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -20,6 +20,7 @@
 
 
 import numpy as np
+import pandas as pd
 
 
 def _isAllZero(y):
@@ -39,6 +40,8 @@ def _isAllZero(y):
     bool
         whether :code:`y` only contains zeroes
     """
+    if isinstance(y, pd.DataFrame):
+        y = y.values
     if len(y) == 0:
         return False
     check_range = (np.amin(y), np.nanmax(y))

--- a/tests/edgepy/test_DGEList.py
+++ b/tests/edgepy/test_DGEList.py
@@ -11,16 +11,27 @@ class test_utils(unittest.TestCase):
         from inmoose.edgepy.utils import _isAllZero
 
         self.assertEqual(_isAllZero(np.array([])), False)
+        self.assertEqual(_isAllZero(pd.DataFrame(np.array([]))), False)
         self.assertEqual(_isAllZero(np.array([0, 0, 0])), True)
+        self.assertEqual(_isAllZero(pd.DataFrame(np.array([0, 0, 0]))), True)
         self.assertEqual(_isAllZero(np.array([2, 1, 0])), False)
+        self.assertEqual(_isAllZero(pd.DataFrame(np.array([2, 1, 0]))), False)
         with self.assertRaisesRegex(
             ValueError, expected_regex="NaN counts are not allowed"
         ):
             _isAllZero(np.array([1, 2, 3, np.nan, 4, 5]))
         with self.assertRaisesRegex(
+            ValueError, expected_regex="NaN counts are not allowed"
+        ):
+            _isAllZero(pd.DataFrame(np.array([1, 2, 3, np.nan, 4, 5])))
+        with self.assertRaisesRegex(
             ValueError, expected_regex="infinite counts are not allowed"
         ):
             _isAllZero(np.array([1, 2, 3, np.inf, 4, 5]))
+        with self.assertRaisesRegex(
+            ValueError, expected_regex="infinite counts are not allowed"
+        ):
+            _isAllZero(pd.DataFrame(np.array([1, 2, 3, np.inf, 4, 5])))
         with self.assertRaisesRegex(
             ValueError, expected_regex="negative counts are not allowed"
         ):
@@ -28,7 +39,15 @@ class test_utils(unittest.TestCase):
         with self.assertRaisesRegex(
             ValueError, expected_regex="negative counts are not allowed"
         ):
+            _isAllZero(pd.DataFrame(np.array([1, 2, 3, -np.inf, 4, 5])))
+        with self.assertRaisesRegex(
+            ValueError, expected_regex="negative counts are not allowed"
+        ):
             _isAllZero(np.array([1, 2, 3, -42, 4, 5]))
+        with self.assertRaisesRegex(
+            ValueError, expected_regex="negative counts are not allowed"
+        ):
+            _isAllZero(pd.DataFrame(np.array([1, 2, 3, -42, 4, 5])))
 
 
 class test_DGEList(unittest.TestCase):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description and Context
See [CR-422].
Also fixes #79 
Long story short, the behavior of `np.amin` is not consistent between pandas dataframes and numpy arrays, _e.g._ about NaN propagation.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] No code (non-breaking change that does not impact code: formatting, build system, documentation...)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Release (version number increment, possibly with documentation updates)



[CR-422]: https://epigenelabsteam.atlassian.net/browse/CR-422?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ