### PR TITLE
Fix small sample size consensus clustering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [0.7.3-dev]
 
+- fix single sample clustering error, changing cluster consensus to nan
 - create `cohort_qc` module with `CohortMetric` and `QCReport` classes to
   evaluate dataset quality after batch effect correction
 - improve `cohort_qc` module when the number of covariates is 0 or 1

--- a/inmoose/consensus_clustering/consensus_clustering.py
+++ b/inmoose/consensus_clustering/consensus_clustering.py
@@ -351,7 +351,7 @@ class consensusClustering:
             ids_ = np.array(list(combinations(np.sort(ids), 2))).T
             if ids_.size == 0:
                 clusters_consensus[clust] = np.nan
-                LOGGER.error(
+                LOGGER.warning(
                     f"Single sample cluster for cluster {str(clust)} of k={k}. Setting cluster consensus to NaN."
                 )
                 continue

--- a/inmoose/consensus_clustering/consensus_clustering.py
+++ b/inmoose/consensus_clustering/consensus_clustering.py
@@ -469,14 +469,21 @@ class consensusClustering:
         Compute cluster consensus for each k from min_k to max_k and return a dataframe to use in the plot_clusters_consensus
         """
         consensus_clusters = []
+        index_name = []
+        single_sample_cluster = []
         for k in range(self.min_k, self.max_k + 1):
             prediction = self.predict(k)
-            consensus_clust = self.compute_clusters_consensus(prediction, k)
-            consensus_clusters.append(consensus_clust)
+            try:
+                consensus_clust = self.compute_clusters_consensus(prediction, k)
+                consensus_clusters.append(consensus_clust)
+                index_name.append(f"k={k}")
+            except IndexError:
+                LOGGER.error(
+                    f"Error while computing cluster consensus for k={k}. Skipping this value."
+                )
+                single_sample_cluster.append(k)
 
-        index_name = [f"k={i}" for i in range(self.min_k, self.max_k + 1)]
-
-        return pd.DataFrame(consensus_clusters, index=index_name)
+        return pd.DataFrame(consensus_clusters, index=index_name), single_sample_cluster
 
     def plot_clusters_consensus(self, cons_clust_df, fig_path):
         """

--- a/tests/cohort_qc/test_cohort_metric.py
+++ b/tests/cohort_qc/test_cohort_metric.py
@@ -238,17 +238,19 @@ class TestCohortMetric(unittest.TestCase):
     def test_process(self):
         """Test process method."""
         # Mock the return values of each method that is called within `process`
-        with mock.patch.object(
-            self.qc, "pca_analysis"
-        ) as mock_pca_analysis, mock.patch.object(
-            self.qc, "quantify_correction_effect"
-        ) as mock_quantify_correction_effect, mock.patch.object(
-            self.qc, "silhouette_score"
-        ) as mock_silhouette_score, mock.patch.object(
-            self.qc, "entropy_batch_mixing"
-        ) as mock_entropy_batch_mixing, mock.patch.object(
-            self.qc, "summarize_and_compare_mixed_datasets"
-        ) as mock_summarize_and_compare_mixed_datasets:
+        with (
+            mock.patch.object(self.qc, "pca_analysis") as mock_pca_analysis,
+            mock.patch.object(
+                self.qc, "quantify_correction_effect"
+            ) as mock_quantify_correction_effect,
+            mock.patch.object(self.qc, "silhouette_score") as mock_silhouette_score,
+            mock.patch.object(
+                self.qc, "entropy_batch_mixing"
+            ) as mock_entropy_batch_mixing,
+            mock.patch.object(
+                self.qc, "summarize_and_compare_mixed_datasets"
+            ) as mock_summarize_and_compare_mixed_datasets,
+        ):
             # Define mock return values for each method
             mock_pca_analysis.return_value = (
                 pd.DataFrame(),  # association_matrix_before

--- a/tests/consensus_clustering/test_consensus_clustering.py
+++ b/tests/consensus_clustering/test_consensus_clustering.py
@@ -1,4 +1,5 @@
 import importlib.resources
+import logging
 import os
 import unittest
 
@@ -94,7 +95,7 @@ class test_consensusClustering(unittest.TestCase):
         self.CC.compute_consensus_clustering(
             self.mocked_data.iloc[:8].to_numpy(), random_state=0
         )
-        with self.assertLogs(level="WARNING") as log:
+        with self.assertLogs("inmoose", level=logging.WARNING) as log:
             cons_clust_df = self.CC.build_clusters_consensus_df()
             self.assertIn(
                 "Single sample cluster for cluster 1 of k=4. Setting cluster consensus to NaN.",

--- a/tests/consensus_clustering/test_consensus_clustering.py
+++ b/tests/consensus_clustering/test_consensus_clustering.py
@@ -94,7 +94,7 @@ class test_consensusClustering(unittest.TestCase):
         self.CC.compute_consensus_clustering(
             self.mocked_data.iloc[:8].to_numpy(), random_state=0
         )
-        with self.assertLogs(level="ERROR") as log:
+        with self.assertLogs(level="WARNING") as log:
             cons_clust_df = self.CC.build_clusters_consensus_df()
             self.assertIn(
                 "Single sample cluster for cluster 1 of k=4. Setting cluster consensus to NaN.",

--- a/tests/consensus_clustering/test_consensus_clustering.py
+++ b/tests/consensus_clustering/test_consensus_clustering.py
@@ -85,14 +85,22 @@ class test_consensusClustering(unittest.TestCase):
         self.CC.compute_consensus_clustering(
             self.mocked_data.to_numpy(), random_state=0
         )
-        cons_clust_df = self.CC.build_clusters_consensus_df()
+        cons_clust_df, single_sample_cluster = self.CC.build_clusters_consensus_df()
         self.CC.plot_clusters_consensus(cons_clust_df, self.consensus_plot)
         assert os.path.exists(self.consensus_plot)
+        assert len(single_sample_cluster) == 0
+
+    def test_clusters_consensus_single_sample(self):
+        self.CC.compute_consensus_clustering(
+            self.mocked_data.iloc[:8].to_numpy(), random_state=0
+        )
+        _, single_sample_cluster = self.CC.build_clusters_consensus_df()
+        assert len(single_sample_cluster) == 1
 
     def test_line_plots_cluster_consensus(self):
         self.CC.compute_consensus_clustering(
             self.mocked_data.to_numpy(), random_state=0
         )
-        cons_clust_df = self.CC.build_clusters_consensus_df()
+        cons_clust_df, _ = self.CC.build_clusters_consensus_df()
         self.CC.line_plots_cluster_consensus(cons_clust_df, self.consensus_line_plot)
         assert os.path.exists(self.consensus_line_plot)

--- a/tests/consensus_clustering/test_consensus_clustering.py
+++ b/tests/consensus_clustering/test_consensus_clustering.py
@@ -85,22 +85,36 @@ class test_consensusClustering(unittest.TestCase):
         self.CC.compute_consensus_clustering(
             self.mocked_data.to_numpy(), random_state=0
         )
-        cons_clust_df, single_sample_cluster = self.CC.build_clusters_consensus_df()
+        cons_clust_df = self.CC.build_clusters_consensus_df()
         self.CC.plot_clusters_consensus(cons_clust_df, self.consensus_plot)
         assert os.path.exists(self.consensus_plot)
-        assert len(single_sample_cluster) == 0
 
     def test_clusters_consensus_single_sample(self):
+        np.random.seed(0)
         self.CC.compute_consensus_clustering(
             self.mocked_data.iloc[:8].to_numpy(), random_state=0
         )
-        _, single_sample_cluster = self.CC.build_clusters_consensus_df()
-        assert len(single_sample_cluster) == 1
+        with self.assertLogs(level="ERROR") as log:
+            cons_clust_df = self.CC.build_clusters_consensus_df()
+            self.assertIn(
+                "Single sample cluster for cluster 1 of k=4. Setting cluster consensus to NaN.",
+                log.output[0],
+            )
+            self.assertIn(
+                "Single sample cluster for cluster 2 of k=4. Setting cluster consensus to NaN.",
+                log.output[1],
+            )
+            self.assertIn(
+                "Single sample cluster for cluster 3 of k=4. Setting cluster consensus to NaN.",
+                log.output[2],
+            )
+
+        assert cons_clust_df.iloc[2].isna().sum() == 3
 
     def test_line_plots_cluster_consensus(self):
         self.CC.compute_consensus_clustering(
             self.mocked_data.to_numpy(), random_state=0
         )
-        cons_clust_df, _ = self.CC.build_clusters_consensus_df()
+        cons_clust_df = self.CC.build_clusters_consensus_df()
         self.CC.line_plots_cluster_consensus(cons_clust_df, self.consensus_line_plot)
         assert os.path.exists(self.consensus_line_plot)


### PR DESCRIPTION
This PR fixes a bug that occurs when we try to compute clusters consensus on a cluster with a single sample, making the computation impossible and raising an indexError

Jira [card](https://epigenelabsteam.atlassian.net/browse/CR-381?atlOrigin=eyJpIjoiYjc5YjE2YmI5NGU5NDI1NGIyOGJlYjE5OGIzZjBmZmMiLCJwIjoiaiJ9)

## Description and Context
As this problem arises on random number of clusters, we have decides to remove the given number from the computation of the clusters consensus, and list all numbers that have raised an error. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] No code (non-breaking change that does not impact code: formatting, build system, documentation...)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Release (version number increment, possibly with documentation updates)

