### PR TITLE
CR 461 improve documentation for plotMA

### DIFF
--- a/docs/source/diffexp.rst
+++ b/docs/source/diffexp.rst
@@ -123,6 +123,6 @@ Code documentation
 .. autosummary::
    :toctree: generated/
 
-   DEResults
+   ~DEResults.DEResults
 
    meta_de

--- a/docs/source/generated/inmoose.diffexp.DEResults.DEResults.rst
+++ b/docs/source/generated/inmoose.diffexp.DEResults.DEResults.rst
@@ -1,0 +1,16 @@
+﻿inmoose.diffexp.DEResults
+=========================
+
+.. currentmodule:: inmoose.diffexp.DEResults
+
+.. autoclass:: DEResults
+
+   .. rubric:: Methods
+
+   .. autosummary::
+      :toctree:
+
+      ~DEResults.__init__
+      ~DEResults.plotMA
+
+

--- a/docs/source/limma.rst
+++ b/docs/source/limma.rst
@@ -205,35 +205,36 @@ Summary and :func:`show` method exists for objects of class
 The results from :func:`decideTests` can also be included when the results of a
 linear model fit are written to a file using :func:`write_fit`.
 
-#Gene Set Tests
-#--------------
-#
-#Competitive gene set testing for an individual gene set is provided by
-#:func:`wilcoxGST` or :func:`geneSetTest`, which permute genes. The gene set can
-#be displayed using :func:`barcodeplot`.
-#
-#Self-contained gene set testing for an individual set is provided by
-#:func:`roast`, which uses rotation technology, analogous to permuting arrays.
-#
-#Gene set enrichment analysis for a large database of gene sets is provided by
-#:func:`romer`. :func:`topRomer` is used to rank results from :func:`romer`.
-#
-#The functions :func:`alias2Symbol`, :func:`alias2SymbolTable` and
-#:func:`alias2SymbolUsingNCBI` are provided to help match gene sets with
-#microarray probes by way of official gene symbols.
-#
-#Global Tests
-#------------
-#
-#The function :func:`genas` can test for associations between two contrasts in a
-#linear model.
-#
-#Given a set of *p*-values, the function :func:`propTrueNull` can be used to
-#estimate the proportion of true null hypothesis.
-#
-#When evaluating test procedures with simulated or known results, the utility
-#function :func:`auROC` can be used to compute the area under the Receiver
-#Operating Curve for the test results for a given probe.
+..
+  Gene Set Tests
+  --------------
+
+  Competitive gene set testing for an individual gene set is provided by
+  :func:`wilcoxGST` or :func:`geneSetTest`, which permute genes. The gene set can
+  be displayed using :func:`barcodeplot`.
+
+  Self-contained gene set testing for an individual set is provided by
+  :func:`roast`, which uses rotation technology, analogous to permuting arrays.
+
+  Gene set enrichment analysis for a large database of gene sets is provided by
+  :func:`romer`. :func:`topRomer` is used to rank results from :func:`romer`.
+
+  The functions :func:`alias2Symbol`, :func:`alias2SymbolTable` and
+  :func:`alias2SymbolUsingNCBI` are provided to help match gene sets with
+  microarray probes by way of official gene symbols.
+
+  Global Tests
+  ------------
+
+  The function :func:`genas` can test for associations between two contrasts in a
+  linear model.
+
+  Given a set of *p*-values, the function :func:`propTrueNull` can be used to
+  estimate the proportion of true null hypothesis.
+
+  When evaluating test procedures with simulated or known results, the utility
+  function :func:`auROC` can be used to compute the area under the Receiver
+  Operating Curve for the test results for a given probe.
 
 
 References


### PR DESCRIPTION
See [CR-461]

This PR makes sure that the function `plotMA` is documented as a method of the class `DEResults`.
See the corresponding RTD pages:
- [class documentation](https://inmoose.readthedocs.io/en/cr-461/generated/inmoose.diffexp.DEResults.DEResults.html#inmoose.diffexp.DEResults.DEResults)
- [method documentation](https://inmoose.readthedocs.io/en/cr-461/generated/inmoose.diffexp.DEResults.DEResults.plotMA.html#inmoose.diffexp.DEResults.DEResults.plotMA)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] No code (non-breaking change that does not impact code: formatting, build system, documentation...)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Release (version number increment, possibly with documentation updates)



[CR-461]: https://epigenelabsteam.atlassian.net/browse/CR-461?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ