### PR TITLE
🐛 Fix pasty issue with space handling and compute silhouette only if multiple batches

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,9 @@ cython_debug/
 
 # IDE settings
 .vscode/
+
+# Virtual environment
+.venv/
+
+# Test results
+tests/**/*.html

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - fix single sample clustering error, changing cluster consensus to nan
 - improve pyDESeq2 documentation 
-- fix some cohort metrics when there is only one batch
+- raise error on cohort metrics when there is only one batch
 - fix patsy formula parsing of categorical variables with spaces in their names
 
 ## [0.7.3]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - fix single sample clustering error, changing cluster consensus to nan
 - improve pyDESeq2 documentation 
+- fix some cohort metrics when there is only one batch
+- fix patsy formula parsing of categorical variables with spaces in their names
 
 ## [0.7.3]
 

--- a/inmoose/cohort_qc/cohort_metric.py
+++ b/inmoose/cohort_qc/cohort_metric.py
@@ -1,5 +1,5 @@
 # -----------------------------------------------------------------------------
-# Copyright (C) 2024 L. Meunier
+# Copyright (C) 2024-2025 L. Meunier
 
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -666,7 +666,6 @@ class CohortMetric:
             Silhouette scores before and after correction.
         """
         if self.clinical_df[self.batch_column].nunique() > 1:
-
             # Compute silhouette score for after batch correction
             score_after = silhouette_score(
                 self.data_expression_df.T, self.clinical_df[self.batch_column]
@@ -675,7 +674,8 @@ class CohortMetric:
             if self.data_expression_df_before is not None:
                 # Compute silhouette score before correction if available
                 score_before = silhouette_score(
-                    self.data_expression_df_before.T, self.clinical_df[self.batch_column]
+                    self.data_expression_df_before.T,
+                    self.clinical_df[self.batch_column],
                 )
             else:
                 score_before = None
@@ -727,7 +727,6 @@ class CohortMetric:
             Entropy values before and after correction.
         """
         if self.clinical_df[self.batch_column].nunique() > 1:
-
             # Compute entropy of batch mixing after batch correction
             entropy_after = self.compute_entropy(self.data_expression_df)
 

--- a/inmoose/cohort_qc/qc_report.py
+++ b/inmoose/cohort_qc/qc_report.py
@@ -63,14 +63,14 @@ class QCReport:
         for covariate in covariates:
             before = None
             if self.cohort_qc.data_expression_df_before is not None:
-                fig_before = self.cohort_qc._pca_plot(
+                fig_before = self.cohort_qc.pca_plot(
                     self.cohort_qc.pcs_before,
                     self.cohort_qc.clinical_df[covariate],
                     title=f"PCA before correction - {covariate}",
                 )
                 before = self.plot_to_base64(fig_before)
 
-            fig_after = self.cohort_qc._pca_plot(
+            fig_after = self.cohort_qc.pca_plot(
                 self.cohort_qc.pcs_after,
                 self.cohort_qc.clinical_df[covariate],
                 title=f"PCA after correction - {covariate}",
@@ -91,7 +91,7 @@ class QCReport:
 
         pca_variance_before = (
             self.plot_to_base64(
-                self.cohort_qc._plot_pca_variance(
+                self.cohort_qc.plot_pca_variance(
                     self.cohort_qc.pca_before.explained_variance_ratio_, ylim
                 )
             )
@@ -100,7 +100,7 @@ class QCReport:
         )
 
         pca_variance_after = self.plot_to_base64(
-            self.cohort_qc._plot_pca_variance(
+            self.cohort_qc.plot_pca_variance(
                 self.cohort_qc.pca_after.explained_variance_ratio_, ylim
             )
         )

--- a/tests/cohort_qc/test_cohort_metric.py
+++ b/tests/cohort_qc/test_cohort_metric.py
@@ -154,6 +154,7 @@ class TestCohortMetric(unittest.TestCase):
 
     def test_create_correlation_matrix_with_pc(self):
         clinical_df_with_pc = self.clinical_df.copy()
+        clinical_df_with_pc["Data Element With Spaces"] = ["value_0", "value_2", "value_1", "value_2"]
         clinical_df_with_pc["PC1"] = [1, 2, 3, 1]
         clinical_df_with_pc["PC2"] = [2, 2, 3, 5]
         result_matrix = self.qc.create_correlation_matrix_with_pc(clinical_df_with_pc)
@@ -202,6 +203,13 @@ class TestCohortMetric(unittest.TestCase):
         self.assertIsInstance(mad_before, float)
         self.assertIsInstance(mad_after, float)
         self.assertIsInstance(effect_metric, float)
+    
+    def test_quantify_correction_effect_only_one_batch(self):
+        self.qc.clinical_df[self.qc.batch_column] = "only_one_batch"
+        mad_before, mad_after, effect_metric = self.qc.quantify_correction_effect()
+        self.assertIsInstance(mad_before, float)
+        self.assertIsInstance(mad_after, float)
+        self.assertIsInstance(effect_metric, float)
 
     @mock.patch("inmoose.cohort_qc.cohort_metric.silhouette_score")
     def test_silhouette_score(self, mock_silhouette_score):
@@ -210,6 +218,10 @@ class TestCohortMetric(unittest.TestCase):
         score_before, score_after = self.qc.silhouette_score()
         self.assertEqual(score_before, 0.3)
         self.assertEqual(score_after, 0.5)
+    
+    def test_silhouette_score_only_one_batch(self):
+        self.qc.clinical_df[self.qc.batch_column] = "only_one_batch"
+        assert self.qc.silhouette_score() == (None, None)
 
     @mock.patch("sklearn.neighbors.NearestNeighbors.kneighbors")
     def test_compute_entropy(self, mock_kneighbors):
@@ -223,6 +235,10 @@ class TestCohortMetric(unittest.TestCase):
         entropy_before, entropy_after = self.qc.entropy_batch_mixing()
         self.assertIsInstance(entropy_before, float)
         self.assertIsInstance(entropy_after, float)
+    
+    def test_entropy_batch_mixing_only_one_batch(self):
+        self.qc.clinical_df[self.qc.batch_column] = "only_one_batch"
+        assert self.qc.entropy_batch_mixing() == (None, None)
 
     @mock.patch("inmoose.cohort_qc.cohort_metric.sns.violinplot")
     def test_compare_sample_distribution_by_covariates(self, mock_violinplot):

--- a/tests/cohort_qc/test_cohort_metric.py
+++ b/tests/cohort_qc/test_cohort_metric.py
@@ -154,7 +154,12 @@ class TestCohortMetric(unittest.TestCase):
 
     def test_create_correlation_matrix_with_pc(self):
         clinical_df_with_pc = self.clinical_df.copy()
-        clinical_df_with_pc["Data Element With Spaces"] = ["value_0", "value_2", "value_1", "value_2"]
+        clinical_df_with_pc["Data Element With Spaces"] = [
+            "value_0",
+            "value_2",
+            "value_1",
+            "value_2",
+        ]
         clinical_df_with_pc["PC1"] = [1, 2, 3, 1]
         clinical_df_with_pc["PC2"] = [2, 2, 3, 5]
         result_matrix = self.qc.create_correlation_matrix_with_pc(clinical_df_with_pc)
@@ -203,7 +208,7 @@ class TestCohortMetric(unittest.TestCase):
         self.assertIsInstance(mad_before, float)
         self.assertIsInstance(mad_after, float)
         self.assertIsInstance(effect_metric, float)
-    
+
     def test_quantify_correction_effect_only_one_batch(self):
         self.qc.clinical_df[self.qc.batch_column] = "only_one_batch"
         mad_before, mad_after, effect_metric = self.qc.quantify_correction_effect()
@@ -218,7 +223,7 @@ class TestCohortMetric(unittest.TestCase):
         score_before, score_after = self.qc.silhouette_score()
         self.assertEqual(score_before, 0.3)
         self.assertEqual(score_after, 0.5)
-    
+
     def test_silhouette_score_only_one_batch(self):
         self.qc.clinical_df[self.qc.batch_column] = "only_one_batch"
         assert self.qc.silhouette_score() == (None, None)
@@ -235,7 +240,7 @@ class TestCohortMetric(unittest.TestCase):
         entropy_before, entropy_after = self.qc.entropy_batch_mixing()
         self.assertIsInstance(entropy_before, float)
         self.assertIsInstance(entropy_after, float)
-    
+
     def test_entropy_batch_mixing_only_one_batch(self):
         self.qc.clinical_df[self.qc.batch_column] = "only_one_batch"
         assert self.qc.entropy_batch_mixing() == (None, None)

--- a/tests/utils/test_format.py
+++ b/tests/utils/test_format.py
@@ -1,16 +1,19 @@
+import unittest
+
 from inmoose.utils import round_scientific_notation, truncate_name
 
 
-def test_round_scientific_notation(self):
-    """Test rounding of small positive numbers."""
-    result = round_scientific_notation(0.0000123456)
-    self.assertEqual(result, "1.23e-05")
+class TestFormat(unittest.TestCase):
+    def test_round_scientific_notation(self):
+        """Test rounding of small positive numbers."""
+        result = round_scientific_notation(0.0000123456)
+        self.assertEqual(result, "1.23e-05")
 
 
-def test_truncate_name(self):
-    """Test case where the name is longer than max_length."""
-    result = truncate_name("ThisNameIsTooLong", 11)
-    self.assertEqual(result, "ThisName...")
+    def test_truncate_name(self):
+        """Test case where the name is longer than max_length."""
+        result = truncate_name("ThisNameIsTooLong", 11)
+        self.assertEqual(result, "ThisName...")
 
-    result = truncate_name("ThisNameIsShort", 15)
-    self.assertEqual(result, "ThisNameIsShort")
+        result = truncate_name("ThisNameIsShort", 15)
+        self.assertEqual(result, "ThisNameIsShort")

--- a/tests/utils/test_format.py
+++ b/tests/utils/test_format.py
@@ -9,7 +9,6 @@ class TestFormat(unittest.TestCase):
         result = round_scientific_notation(0.0000123456)
         self.assertEqual(result, "1.23e-05")
 
-
     def test_truncate_name(self):
         """Test case where the name is longer than max_length."""
         result = truncate_name("ThisNameIsTooLong", 11)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description and Context
<!-- Describe your changes here -->
<!-- Link your PR to the corresponding JIRA ticket by adding the identifier of your JIRA ticket in brackets (e.g. [JRA-33]) -->
<!-- Feel free to add sections if needed (e.g. "Test strategy" or "Compliance") -->
This PR aims to fix different issues:
- pasty formula not supporting spaces in clinical data element names
- not computing cohort metrics with only one batch
- not processing cohort metrics on `__init__` to let the user decide what to trigger when
- fix unit tests missing class

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] No code (non-breaking change that does not impact code: formatting, build system, documentation...)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Release (version number increment, possibly with documentation updates)

